### PR TITLE
Add !define for prompts

### DIFF
--- a/apps/sue/lib/sue/commands/core.ex
+++ b/apps/sue/lib/sue/commands/core.ex
@@ -102,7 +102,7 @@ defmodule Sue.Commands.Core do
           "Hmm, I couldn't find that command. See the list of commands with !help"
 
         {_, _, ""} ->
-          "No documentation for that yet. Let us know! https://github.com/inculi/Sue"
+          "No documentation for that yet. Let us know! https://github.com/Manwholikespie/Sue"
 
         {_, _, doc} ->
           doc

--- a/apps/sue/lib/sue/commands/defns.ex
+++ b/apps/sue/lib/sue/commands/defns.ex
@@ -13,46 +13,106 @@ defmodule Sue.Commands.Defns do
   alias Sue.Models.{Defn, Message, Response}
   alias Sue.DB
 
+  @gpt_rate_limit Application.compile_env(:sue, :gpt_rate_limit)
+
   def calldefn(msg) do
-    # meaning = get_defn!(msg) || "Command not found. Add it with !define."
     varname = msg.command
 
-    case DB.find_defn(msg.account.id, msg.chat.is_direct, varname) do
-      {:ok, %Defn{val: val}} -> %Response{body: val}
-      {:error, :dne} -> %Response{body: "Command not found. Add it with !define."}
+    with {:ok, defn} <- DB.find_defn(msg.account.id, msg.chat.is_direct, varname) do
+      calldefn_type(msg, defn)
+    else
+      {:error, :dne} ->
+        %Response{body: "Command not found. Add it with !define."}
+    end
+  end
+
+  def calldefn_type(_msg, %Defn{type: :text, val: val}), do: %Response{body: val}
+
+  def calldefn_type(%Message{args: ""}, %Defn{type: :prompt}),
+    do: %Response{
+      body: "This definition is a prompt, and must be called with args. See !help define"
+    }
+
+  def calldefn_type(msg, %Defn{type: :prompt, val: val}) do
+    prompt = String.replace(val, "$args", msg.args)
+
+    with :ok <-
+           Sue.Limits.check_rate("gpt:#{msg.account.id}", @gpt_rate_limit, msg.account.is_premium) do
+      %Response{body: Sue.AI.raw_chat_completion_text(prompt)}
+    else
+      :deny -> %Response{body: "Please slow down your requests. Try again in 24 hours."}
     end
   end
 
   @spec c_define(atom | %{:args => binary, optional(any) => any}) :: Sue.Models.Response.t()
   @doc """
-  Create a quick alias that makes Sue say something.
-  Usage: !define <word> <... meaning ...>
+  Create a quick alias that makes Sue say something or do something.
+  Usage: !define [type] <word> <... value ...>
+
+  Supported types:
+    - text (default): Creates a simple text response
+    - prompt: Creates a template for asking ChatGPT
+
+  Examples:
   ---
   You: !define myword this is my definition
   Sue: myword updated.
   You: !myword
   Sue: this is my definition
+
+  You: !define prompt poem Write a poem about $args.
+  Sue: poem updated.
+  You: !poem bruh
+  Sue: Bruh moment-- silence louder than words.
   """
   def c_define(%Message{args: ""}),
     do: %Response{body: "Please supply a word and meaning. See !help define"}
 
   def c_define(msg) do
-    case msg.args |> String.split(" ", parts: 2) do
-      [_word] ->
-        %Response{body: "Please supply a meaning for the word. See !help define"}
+    # Split args into up to 3 parts: [type, var, val] or [var, val]
+    parts = msg.args |> String.split(" ", parts: 3)
 
-      [word, val] ->
-        var = word |> String.downcase()
+    {type, var, val} =
+      case parts do
+        # If we have 3 parts, check if the first one is a valid type
+        ["text", var, val] ->
+          {:text, var, val}
 
-        if String.contains?(var, "@") do
-          %Response{body: "Please don't put @ symbols in definitions."}
-        else
-          {:ok, _} =
-            Defn.new(var, val, :text)
-            |> DB.add_defn(msg.account.id, msg.chat.id)
+        ["prompt", var, val] ->
+          {:prompt, var, val}
 
-          %Response{body: "#{var} updated."}
-        end
+        # If the first part is not a valid type, or we only have 2 parts,
+        # assume default type (:text)
+        [var, val] ->
+          {:text, var, val}
+
+        [first, second, third] ->
+          {:text, first, second <> " " <> third}
+
+        [_] ->
+          {nil, nil, nil}
+      end
+
+    cond do
+      is_nil(type) ->
+        %Response{body: "Please supply a word and meaning. See !help define"}
+
+      String.contains?(var, "@") ->
+        %Response{body: "Please don't put @ symbols in definitions."}
+
+      type == :prompt and not String.contains?(val, "$args") ->
+        %Response{
+          body: "Prompts must have $args where they want args to be injected. See !help define"
+        }
+
+      true ->
+        var = var |> String.downcase()
+
+        {:ok, _} =
+          Defn.new(var, val, type)
+          |> DB.add_defn(msg.account.id, msg.chat.id)
+
+        %Response{body: "#{var} updated."}
     end
   end
 
@@ -68,24 +128,16 @@ defmodule Sue.Commands.Defns do
       |> Enum.map(fn d -> d.id end)
       |> MapSet.new()
 
-    defn_user_list =
-      case defn_user
-           |> Enum.uniq_by(fn d -> d.var end)
-           |> Enum.map(fn d -> "- #{d.var}" end)
-           |> Enum.join("\n") do
-        "" -> ""
-        otherwise -> "defns by user:\n" <> otherwise
-      end
+    defn_user_by_type = group_defns_by_type(defn_user)
 
-    defn_chat_list =
-      case DB.get_defns_by_chat(msg.chat.id)
-           |> Enum.filter(fn d -> not MapSet.member?(defn_user_ids, d.id) end)
-           |> Enum.uniq_by(fn d -> d.var end)
-           |> Enum.map(fn d -> "- #{d.var}" end)
-           |> Enum.join("\n") do
-        "" -> ""
-        otherwise -> "defns by chat:\n" <> otherwise
-      end
+    defn_chat =
+      DB.get_defns_by_chat(msg.chat.id)
+      |> Enum.filter(fn d -> not MapSet.member?(defn_user_ids, d.id) end)
+
+    defn_chat_by_type = group_defns_by_type(defn_chat)
+
+    defn_user_list = format_defns_by_type(defn_user_by_type, "user")
+    defn_chat_list = format_defns_by_type(defn_chat_by_type, "chat")
 
     %Response{
       body:
@@ -94,5 +146,51 @@ defmodule Sue.Commands.Defns do
           otherwise -> otherwise
         end
     }
+  end
+
+  # Helper to group definitions by type
+  defp group_defns_by_type(defns) do
+    defns
+    |> Enum.group_by(fn d -> d.type end)
+    |> Enum.map(fn {type, defs} ->
+      {type, Enum.uniq_by(defs, fn d -> d.var end)}
+    end)
+    |> Enum.into(%{})
+  end
+
+  # Helper to format definitions grouped by type
+  defp format_defns_by_type(defns_by_type, source) do
+    if Enum.empty?(defns_by_type) do
+      ""
+    else
+      result = "defns by #{source}:\n"
+
+      # First, show text type definitions (the most common)
+      text_defns = Map.get(defns_by_type, :text, [])
+
+      text_section =
+        if Enum.empty?(text_defns) do
+          ""
+        else
+          text_defns
+          |> Enum.map(fn d -> "- #{d.var}" end)
+          |> Enum.join("\n")
+        end
+
+      # Then show other types with their type annotation
+      other_sections =
+        defns_by_type
+        |> Enum.filter(fn {type, _} -> type != :text end)
+        |> Enum.map(fn {type, defs} ->
+          defs
+          |> Enum.map(fn d -> "- #{d.var} (#{type})" end)
+          |> Enum.join("\n")
+        end)
+        |> Enum.join("\n")
+
+      result <>
+        text_section <>
+        if(text_section != "" and other_sections != "", do: "\n", else: "") <> other_sections
+    end
   end
 end

--- a/apps/sue/lib/sue/commands/gpt.ex
+++ b/apps/sue/lib/sue/commands/gpt.ex
@@ -16,7 +16,7 @@ defmodule Sue.Commands.Gpt do
     # Check rate limit for using gpt command: 50/day
     with :ok <- Sue.Limits.check_rate("gpt:#{account.id}", @gpt_rate_limit, account.is_premium) do
       %Response{
-        body: Sue.AI.chat_completion(args, :gpt4omini, chat, account),
+        body: Sue.AI.chat_completion(args, chat, account),
         is_from_gpt: true
       }
     else
@@ -36,7 +36,7 @@ defmodule Sue.Commands.Gpt do
   end
 
   def c_h_gpt4(%Message{args: args, chat: chat, account: %Account{is_premium: true} = account}) do
-    %Response{body: Sue.AI.chat_completion(args, :gpt4o, chat, account), is_from_gpt: true}
+    %Response{body: Sue.AI.chat_completion(args, chat, account, :gpt4o), is_from_gpt: true}
   end
 
   @doc """

--- a/apps/sue/lib/sue/commands/poll.ex
+++ b/apps/sue/lib/sue/commands/poll.ex
@@ -37,7 +37,7 @@ defmodule Sue.Commands.Poll do
         %Poll{interface: :platform} ->
           %Response{body: "Please use this messenger's custom polling interface."}
 
-        p ->
+        _p ->
           vote(poll, msg)
       end
     else

--- a/apps/sue/lib/sue/db/migrations/m_1694479355.ex
+++ b/apps/sue/lib/sue/db/migrations/m_1694479355.ex
@@ -1,6 +1,6 @@
 defmodule Sue.DB.Migrations.M1694479355 do
   @moduledoc """
-  https://github.com/inculi/Sue/pull/45
+  https://github.com/Manwholikespie/Sue/pull/45
 
   Move Account.platform_id metadata into a PlatformAccount.
   Create connect the two via an edge (sue_user_by_platformaccount).

--- a/apps/sue/lib/sue/models/defn.ex
+++ b/apps/sue/lib/sue/models/defn.ex
@@ -7,7 +7,7 @@ defmodule Sue.Models.Defn do
   @type t() :: %__MODULE__{
           var: bitstring(),
           val: bitstring() | integer(),
-          type: :text | :num | :bin | :func,
+          type: :text | :prompt | :bin | :func,
           date_created: integer(),
           date_modified: integer(),
           id: Subaru.dbid() | nil
@@ -17,9 +17,9 @@ defmodule Sue.Models.Defn do
 
   alias __MODULE__
 
-  # TODO: Add support for more defn types (currently just :text)
+  # Support for multiple defn types
   @spec new(bitstring(), bitstring(), atom()) :: t
-  def new(var, val, :text = type) when is_bitstring(var) and is_bitstring(val) do
+  def new(var, val, type) when is_bitstring(var) and is_bitstring(val) and type in [:text, :prompt] do
     now = Sue.Utils.unix_now()
 
     %Defn{


### PR DESCRIPTION
Added Barret's old idea for letting users define gpt prompts then use them as commands. It is used like so:

`!define prompt poem Write a poem about $args.`

In the future, if there is a need, I can add more variables like $name or $time, etc. so that users can choose to inject more context to their prompts or not. Originally I had it as $input (as the plurality of args is confusing when you can't index it), but given that we're injecting Message.args, I figured I'd keep the naming convention the same.

I don't want to do too fancy of functions yet (the Defn :func type). I figure the implementation of that will likely involve the sandboxed WASM Python that OpenAI uses for code interpreter, called over a Rust NIF. That's long off.

Enjoy.