### PR TITLE
Add Martha Stewart incarceration unit to !rub countdown

### DIFF
--- a/apps/sue/lib/sue/commands/dumb.ex
+++ b/apps/sue/lib/sue/commands/dumb.ex
@@ -55,6 +55,7 @@ defmodule Sue.Commands.Dumb do
        "#{round(seconds / 1200)} ice hockey periods",
        "#{trunc(960 * hours)} human breaths",
        "#{:erlang.float_to_binary(days / 12, decimals: 2)} Virginian opossum gestation periods",
+      "#{:erlang.float_to_binary(hours / 3522.5, decimals: 4)} Martha Stewart incarcerations",
        "#{trunc(seconds / 66.46)} smoker deaths",
        "#{trunc(seconds / 180)} Perilla tea steepings",
        "#{trunc(seconds / 150)} commercial breaks",


### PR DESCRIPTION
## Summary
- Include "Martha Stewart incarcerations" as a possible time unit in !rub countdowns with four-decimal precision

## Testing
- `mix deps.get` *(fails: could not read file "config/config.secret.exs")*
- `mix test` *(fails: could not read file "config/config.secret.exs")*

------
https://chatgpt.com/codex/tasks/task_e_68b944759cbc832aaea6ebbac032514d