### PR TITLE
Update GPT integration to use gpt-5-nano model

### DIFF
--- a/apps/sue/lib/sue/commands/gpt.ex
+++ b/apps/sue/lib/sue/commands/gpt.ex
@@ -25,21 +25,6 @@ defmodule Sue.Commands.Gpt do
   end
 
   @doc """
-  Asks ChatGPT a question, using the newer GPT-4 model. Only available to premium users for now.
-  Usage !gpt4 write a poem about a bot named sue
-  """
-  def c_h_gpt4(%Message{account: %Account{is_premium: false}}) do
-    %Response{
-      body:
-        "Sorry, this command is only available for premium Sue users. Check back later for more info, or use !gpt instead."
-    }
-  end
-
-  def c_h_gpt4(%Message{args: args, chat: chat, account: %Account{is_premium: true} = account}) do
-    %Response{body: Sue.AI.chat_completion(args, chat, account, :gpt4o), is_from_gpt: true}
-  end
-
-  @doc """
   Prompt an emoji-finetuned stable diffusion model.
   Usage: !emoji Ryan Gosling
   """

--- a/apps/sue/lib/sue/mailbox/i_message.ex
+++ b/apps/sue/lib/sue/mailbox/i_message.ex
@@ -57,9 +57,6 @@ defmodule Sue.Mailbox.IMessage do
     Imessaged.send_message_to_buddy(rsp.body, account_id)
   end
 
-  # TODO: This would only work for iMessage groups, not SMS. Which for me personally
-  #   is how I'd want it to be, but others may not. Changing it now would affect
-  #   group IDs though, most likely.
   defp send_response_text(%Message{chat: %Chat{is_direct: false}} = msg, rsp) do
     {_platform, chat_identifier} = msg.chat.platform_id
     service = Map.get(msg.metadata, :service, "iMessage")


### PR DESCRIPTION
Replace GPT-4o/GPT-4o-mini model selection with gpt-5-nano. Remove premium-only !gpt4 command and simplify model configuration to support single model version. Clean up unused iMessage comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)